### PR TITLE
Adding default files for contributing, security, licensing, pull_requests, and code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+scramblegenerator@proton.me.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+## How to contribute to the Systemwide ADB Installer
+
+#### Did you find a bug?
+
+- Do not open up a GitHub issue if the bug is a security vulnerability, and instead to refer to our [Security Policy](https://github.com/haridhayal11/Systemwide_ADB_Installer/security/policy).
+
+- Ensure the bug was not already reported by searching on GitHub under [Issues](https://github.com/haridhayal11/Systemwide_ADB_Installer/issues).
+
+- If you're unable to find an open issue addressing the problem, [open a new bug report](https://github.com/haridhayal11/Systemwide_ADB_Installer/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=). Be sure to include a title and clear description of the issue, as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring.
+
+#### Did you write a patch that fixes a bug?
+
+- Open a new GitHub pull request with the patch.
+
+- Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+#### Do you intend to add a new feature or change an existing one?
+
+- Consider [opening a new feature request](https://github.com/haridhayal11/Systemwide_ADB_Installer/issues/new?assignees=&labels=&projects=&template=feature_request.md&title=).
+
+- If you want to try your hand at implementing the feature, [open a pull request](https://github.com/haridhayal11/Systemwide_ADB_Installer/compare) once you have a working and tested version.
+
+#### Any other questions/comments/concerns?
+
+- Please feel free to open an [issue](https://github.com/haridhayal11/Systemwide_ADB_Installer/issues) with the question label and we will respond as soon as we can!
+
+App made with :heart:,
+
+The Systemwide ADB Installer Team

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+
+As this script doesn't have a downloadable release, there will be no "supported versions". We will update code to whatever is compatible with PowerShell as Microsoft pushes updates to it.
+
+## Reporting a Vulnerability
+
+Here's how you can [report a known vulnerability](https://github.com/haridhayal11/Systemwide_ADB_Installer/security/advisories/new).
+
+We will do our best to update the Systemwide ADB Installer Code / and the PowerShell version we're running as soon as possible to correct any known vulnerabilities.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+#### You can erase any parts of this template not applicable to your Pull Request.
+
+### All Submissions:
+
+- [ ] Have you followed the guidelines in our [contributing](../CONTRIBUTING.md) document?
+- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
+
+### New Feature Submissions:
+
+1. [ ] Have you checked your code locally before submitting this PR to make sure it works without issue?
+
+### Changes to Core Features:
+
+- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
+- [ ] Have you written new tests for your core changes and run them locally?

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Haridhayal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adding a bunch of "default" files. This pull request is more of a recommendation than anything else. I have templates set up for all of these myself for my projects, so I thought I'd see if you wanted them added as well since this project didn't have any.